### PR TITLE
Edited description and README. Parallelized fast SPA tests and fixed …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,8 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 LinkingTo: 
-    RcppArmadillo,
     Rcpp,
-    dqrng
+    RcppArmadillo,
+    dqrng,
+    BH,
+    sitmo

--- a/R/Fast_Test_aSPA.R
+++ b/R/Fast_Test_aSPA.R
@@ -27,7 +27,9 @@
 Fast_Test_aSPA <- function(LossDiff, 
                            weights = NULL, 
                            L, 
-                           B=999){
+                           B=999,
+                           num_cores = 1,
+                           seed = 42){
   
   
   if (!is.matrix(LossDiff)){LossDiff <- as.matrix(LossDiff)}
@@ -48,7 +50,9 @@ Fast_Test_aSPA <- function(LossDiff,
   ret <- Test_aSPA_cpp(as.matrix(LossDiff),
                        weights,
                        L, 
-                       B)
+                       B,
+                       num_cores,
+                       seed)
   
   # bootout <- Bootstrap_uSPA(LossDiff, L, B)
   # p_value <- mean(bootout$t_uSPA < bootout$t_uSPA_b)
@@ -56,7 +60,7 @@ Fast_Test_aSPA <- function(LossDiff,
   
   
   
-  return(list("p_value"=ret[[0]], "t_aSPA"=ret[[1]]))
+  return(list("p_value"=ret[[1]], "t_aSPA"=ret[[2]]))
   
   
 }

--- a/R/Fast_Test_uSPA.R
+++ b/R/Fast_Test_uSPA.R
@@ -24,14 +24,18 @@
 
 Fast_Test_uSPA <- function(LossDiff, 
                            L, 
-                           B=999){
+                           B=999,
+                           num_cores = 1,
+                           seed = 42){
   
   
   if (!is.matrix(LossDiff)){LossDiff <- as.matrix(LossDiff)}
   
   ret <- Test_uSPA_cpp(as.matrix(LossDiff), 
                        L, 
-                       B)
+                       B,
+                       num_cores,
+                       seed)
   
   # bootout <- Bootstrap_uSPA(LossDiff, L, B)
   # p_value <- mean(bootout$t_uSPA < bootout$t_uSPA_b)
@@ -39,7 +43,7 @@ Fast_Test_uSPA <- function(LossDiff,
   
   
   
-  return(list("p_value"=ret[[0]], "t_uSPA"=ret[[1]]))
+  return(list("p_value"=ret[[1]], "t_uSPA"=ret[[2]]))
   
   
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,20 +17,20 @@ MBB_Variance_cpp <- function(y, L) {
     .Call(`_MultiHorizonSPA_MBB_Variance_cpp`, y, L)
 }
 
-Bootstrap_aSPA_cpp <- function(Loss_Diff, weights, L, B) {
-    .Call(`_MultiHorizonSPA_Bootstrap_aSPA_cpp`, Loss_Diff, weights, L, B)
+Bootstrap_aSPA_cpp <- function(Loss_Diff, weights, L, B, ncores, seed) {
+    .Call(`_MultiHorizonSPA_Bootstrap_aSPA_cpp`, Loss_Diff, weights, L, B, ncores, seed)
 }
 
-Bootstrap_uSPA_cpp <- function(Loss_Diff, L, B) {
-    .Call(`_MultiHorizonSPA_Bootstrap_uSPA_cpp`, Loss_Diff, L, B)
+Bootstrap_uSPA_cpp <- function(Loss_Diff, L, B, ncores, seed) {
+    .Call(`_MultiHorizonSPA_Bootstrap_uSPA_cpp`, Loss_Diff, L, B, ncores, seed)
 }
 
-Test_aSPA_cpp <- function(LossDiff, weights, L, B) {
-    .Call(`_MultiHorizonSPA_Test_aSPA_cpp`, LossDiff, weights, L, B)
+Test_aSPA_cpp <- function(LossDiff, weights, L, B, ncores, seed) {
+    .Call(`_MultiHorizonSPA_Test_aSPA_cpp`, LossDiff, weights, L, B, ncores, seed)
 }
 
-Test_uSPA_cpp <- function(LossDiff, L, B) {
-    .Call(`_MultiHorizonSPA_Test_uSPA_cpp`, LossDiff, L, B)
+Test_uSPA_cpp <- function(LossDiff, L, B, ncores, seed) {
+    .Call(`_MultiHorizonSPA_Test_uSPA_cpp`, LossDiff, L, B, ncores, seed)
 }
 
 MultiHorizonMCS_cpp <- function(Losses, alpha_t, alpha_mcs, weights, L, B, unif_or_avg, ncores, seed) {

--- a/README.md
+++ b/README.md
@@ -27,13 +27,12 @@ Test for uniform SPA (uSPA).
 
 ``` r
 library(MultiHorizonSPA)
-data(LossDiff_uSPA)
-Test_uSPA(LossDiff=LossDiff_uSPA, L=3)
-#> $p_value
-#> [1] 0.003003003
-#> 
-#> $t_uSPA
-#> [1] 0.0804403
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Test_uSPA(LossDiff=Losses, L=3, B=5)
 ```
 
 The output of the `Test_uSPA` function is a list containing two objects:
@@ -46,14 +45,13 @@ Now test for average SPA (aSPA).
 
 ``` r
 library(MultiHorizonSPA)
-data(LossDiff_aSPA)
-weights <- t(as.matrix(rep(1, ncol(LossDiff_aSPA))/ncol(LossDiff_aSPA)))
-Test_aSPA(LossDiff=LossDiff_aSPA, weights=weights, L=3)
-#> $p_value
-#> [1] 0.002002002
-#> 
-#> $t_aSPA
-#> [1] 2.439664
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+weights <- rep(1/H,H)
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Test_aSPA(LossDiff=Losses, weights=weights, L=3, B=5)
 ```
 
 The output of the `Test_aSPA` function is a list containing two objects:
@@ -61,6 +59,107 @@ The output of the `Test_aSPA` function is a list containing two objects:
   - p-value: the p-value for aSPA;
 
   - t\_aSPA: the statistics for aSPA.
+
+
+## Fast SPA tests
+
+
+``` r
+library(MultiHorizonSPA)
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Fast_Test_uSPA(LossDiff=Losses, L=3, B=10)
+```
+
+
+``` r
+library(MultiHorizonSPA)
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+weights <- rep(1/H,H)
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Fast_Test_aSPA(LossDiff=Losses, weights=weights, L=3, B=10)
+```
+
+
+## Multiple Horizon Model Confidence Set
+
+Note: This test can be computationally expensive. The Fast MCS test is reccommended.
+
+``` r
+library(MultiHorizonSPA)
+Trow <- 20 
+H <- 12
+Mmethods <- 9
+weights <- rep(1/H,H)
+
+loss_list <- vector(mode = "list", length = Mmethods)
+
+loss_list[[1]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[2]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[3]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[4]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[5]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[6]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[7]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[8]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[9]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[10]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+
+
+MultiHorizonMCS(loss_list, L=3,B=5,unif_or_average = 'u')
+#'
+```
+
+
+## Fast Multiple Horizon Model Confidence Set
+
+
+``` r
+library(MultiHorizonSPA)
+Trow <- 20 
+H <- 12
+Mmethods <- 9
+weights <- rep(1/H,H)
+
+loss_list <- vector(mode = "list", length = Mmethods)
+
+loss_list[[1]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[2]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[3]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[4]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[5]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[6]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[7]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[8]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[9]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[10]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+
+
+num_cores <- 1
+
+
+MultiHorizonSPA:::MultiHorizonMCS_cpp(loss_list, #
+                                      0.05, # alpha_t
+                                      0.05, # alpha_mcs
+                                      weights, #
+                                      3,#l
+                                      5,#b
+                                      1, # 1 means uniform
+                                      num_cores,
+                                      seed
+)
+```
+
+
+
+
+
 
 ## References:
 

--- a/man/FastMultiHorizonMCS.Rd
+++ b/man/FastMultiHorizonMCS.Rd
@@ -46,5 +46,38 @@ Produces Multi-Horizon Model Confidence Set and p-values as described in section
 \examples{
 
 
+Trow <- 20 
+H <- 12
+Mmethods <- 9
+weights <- rep(1/H,H)
+
+loss_list <- vector(mode = "list", length = Mmethods)
+
+loss_list[[1]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[2]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[3]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[4]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[5]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[6]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[7]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[8]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[9]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[10]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+
+
+num_cores <- 1
+
+
+MultiHorizonSPA:::MultiHorizonMCS_cpp(loss_list, #
+                                      0.05, # alpha_t
+                                      0.05, # alpha_mcs
+                                      weights, #
+                                      3,#l
+                                      5,#b
+                                      1, # 1 means uniform
+                                      num_cores,
+                                      seed
+)
+
 
 }

--- a/man/Fast_Test_aSPA.Rd
+++ b/man/Fast_Test_aSPA.Rd
@@ -4,7 +4,7 @@
 \alias{Fast_Test_aSPA}
 \title{Fast Test average Superior Predictive Ability}
 \usage{
-Fast_Test_aSPA(LossDiff, weights = NULL, L, B = 999)
+Fast_Test_aSPA(LossDiff, weights = NULL, L, B = 999, num_cores = 1, seed = 42)
 }
 \arguments{
 \item{LossDiff}{the T x H matrix forecast path loss differential}
@@ -25,9 +25,13 @@ Implements the test for average Superior Predictive Ability (aSPA) of Quaedvlieg
 }
 \examples{
 ## Test for aSPA and uSPA
-data(LossDiff_aSPA)
-weights <- matlab::ones(1,20)/20
-Fast_Test_aSPA(LossDiff=LossDiff_aSPA, weights=weights, L=3, B=10)
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+weights <- rep(1/H,H)
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Fast_Test_aSPA(LossDiff=Losses, weights=weights, L=3, B=10)
 
 }
 \references{

--- a/man/Fast_Test_uSPA.Rd
+++ b/man/Fast_Test_uSPA.Rd
@@ -4,7 +4,7 @@
 \alias{Fast_Test_uSPA}
 \title{Fast Test uniform Superior Predictive Ability}
 \usage{
-Fast_Test_uSPA(LossDiff, L, B = 999)
+Fast_Test_uSPA(LossDiff, L, B = 999, num_cores = 1, seed = 42)
 }
 \arguments{
 \item{LossDiff}{the T x H matrix forecast path loss differential}
@@ -23,8 +23,12 @@ Implements the test for uniform Superior Predictive Ability (uSPA) of Quaedvlieg
 }
 \examples{
 ## Test for uSPA
-data(LossDiff_uSPA)
-Fast_Test_uSPA(LossDiff=LossDiff_uSPA, L=3, B=10)
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Fast_Test_uSPA(LossDiff=Losses, L=3, B=10)
 
 }
 \references{

--- a/man/MultiHorizonMCS.Rd
+++ b/man/MultiHorizonMCS.Rd
@@ -40,5 +40,26 @@ Produces Multi-Horizon Model Confidence Set and p-values as described in section
 \examples{
 
 
+Trow <- 20 
+H <- 12
+Mmethods <- 9
+weights <- rep(1/H,H)
+
+loss_list <- vector(mode = "list", length = Mmethods)
+
+loss_list[[1]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[2]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[3]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[4]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[5]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[6]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+loss_list[[7]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[8]] <- matrix(rnorm(Trow*H, mean = 3), nrow = Trow, ncol = H)
+loss_list[[9]] <- matrix(rnorm(Trow*H, mean = 2), nrow = Trow, ncol = H)
+loss_list[[10]] <- matrix(rnorm(Trow*H, mean = 1), nrow = Trow, ncol = H)
+
+
+MultiHorizonMCS(loss_list, L=3,B=5,unif_or_average = 'u')
+
 
 }

--- a/man/Test_aSPA.Rd
+++ b/man/Test_aSPA.Rd
@@ -25,9 +25,14 @@ Implements the test for average Superior Predictive Ability (aSPA) of Quaedvlieg
 }
 \examples{
 ## Test for aSPA and uSPA
-data(LossDiff_aSPA)
-weights <- matlab::ones(1,20)/20
-Test_aSPA(LossDiff=LossDiff_aSPA, weights=weights, L=3, B=10)
+
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+weights <- rep(1/H,H)
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Test_aSPA(LossDiff=Losses, weights=weights, L=3, B=5)
 
 }
 \references{

--- a/man/Test_uSPA.Rd
+++ b/man/Test_uSPA.Rd
@@ -23,8 +23,13 @@ Implements the test for uniform Superior Predictive Ability (uSPA) of Quaedvlieg
 }
 \examples{
 ## Test for uSPA
-data(LossDiff_uSPA)
-Test_uSPA(LossDiff=LossDiff_uSPA, L=3, B=10)
+
+Trow <- 200 
+H <- 12
+Mmethods <- 5
+Losses <- matrix(rnorm(Trow*H, mean = 0), nrow = Trow, ncol = H)
+
+Test_uSPA(LossDiff=Losses, L=3, B=5)
 
 }
 \references{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -58,8 +58,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // Bootstrap_aSPA_cpp
-arma::field<arma::vec> Bootstrap_aSPA_cpp(arma::mat Loss_Diff, arma::vec weights, int L, int B);
-RcppExport SEXP _MultiHorizonSPA_Bootstrap_aSPA_cpp(SEXP Loss_DiffSEXP, SEXP weightsSEXP, SEXP LSEXP, SEXP BSEXP) {
+arma::field<arma::vec> Bootstrap_aSPA_cpp(arma::mat Loss_Diff, arma::vec weights, int L, int B, int ncores, int seed);
+RcppExport SEXP _MultiHorizonSPA_Bootstrap_aSPA_cpp(SEXP Loss_DiffSEXP, SEXP weightsSEXP, SEXP LSEXP, SEXP BSEXP, SEXP ncoresSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -67,26 +67,30 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::vec >::type weights(weightsSEXP);
     Rcpp::traits::input_parameter< int >::type L(LSEXP);
     Rcpp::traits::input_parameter< int >::type B(BSEXP);
-    rcpp_result_gen = Rcpp::wrap(Bootstrap_aSPA_cpp(Loss_Diff, weights, L, B));
+    Rcpp::traits::input_parameter< int >::type ncores(ncoresSEXP);
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    rcpp_result_gen = Rcpp::wrap(Bootstrap_aSPA_cpp(Loss_Diff, weights, L, B, ncores, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // Bootstrap_uSPA_cpp
-arma::field<arma::vec> Bootstrap_uSPA_cpp(arma::mat Loss_Diff, int L, int B);
-RcppExport SEXP _MultiHorizonSPA_Bootstrap_uSPA_cpp(SEXP Loss_DiffSEXP, SEXP LSEXP, SEXP BSEXP) {
+arma::field<arma::vec> Bootstrap_uSPA_cpp(arma::mat Loss_Diff, int L, int B, int ncores, int seed);
+RcppExport SEXP _MultiHorizonSPA_Bootstrap_uSPA_cpp(SEXP Loss_DiffSEXP, SEXP LSEXP, SEXP BSEXP, SEXP ncoresSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< arma::mat >::type Loss_Diff(Loss_DiffSEXP);
     Rcpp::traits::input_parameter< int >::type L(LSEXP);
     Rcpp::traits::input_parameter< int >::type B(BSEXP);
-    rcpp_result_gen = Rcpp::wrap(Bootstrap_uSPA_cpp(Loss_Diff, L, B));
+    Rcpp::traits::input_parameter< int >::type ncores(ncoresSEXP);
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    rcpp_result_gen = Rcpp::wrap(Bootstrap_uSPA_cpp(Loss_Diff, L, B, ncores, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // Test_aSPA_cpp
-List Test_aSPA_cpp(NumericMatrix LossDiff, NumericVector weights, int L, int B);
-RcppExport SEXP _MultiHorizonSPA_Test_aSPA_cpp(SEXP LossDiffSEXP, SEXP weightsSEXP, SEXP LSEXP, SEXP BSEXP) {
+List Test_aSPA_cpp(NumericMatrix LossDiff, NumericVector weights, int L, int B, int ncores, int seed);
+RcppExport SEXP _MultiHorizonSPA_Test_aSPA_cpp(SEXP LossDiffSEXP, SEXP weightsSEXP, SEXP LSEXP, SEXP BSEXP, SEXP ncoresSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -94,20 +98,24 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type weights(weightsSEXP);
     Rcpp::traits::input_parameter< int >::type L(LSEXP);
     Rcpp::traits::input_parameter< int >::type B(BSEXP);
-    rcpp_result_gen = Rcpp::wrap(Test_aSPA_cpp(LossDiff, weights, L, B));
+    Rcpp::traits::input_parameter< int >::type ncores(ncoresSEXP);
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    rcpp_result_gen = Rcpp::wrap(Test_aSPA_cpp(LossDiff, weights, L, B, ncores, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // Test_uSPA_cpp
-List Test_uSPA_cpp(NumericMatrix LossDiff, int L, int B);
-RcppExport SEXP _MultiHorizonSPA_Test_uSPA_cpp(SEXP LossDiffSEXP, SEXP LSEXP, SEXP BSEXP) {
+List Test_uSPA_cpp(NumericMatrix LossDiff, int L, int B, int ncores, int seed);
+RcppExport SEXP _MultiHorizonSPA_Test_uSPA_cpp(SEXP LossDiffSEXP, SEXP LSEXP, SEXP BSEXP, SEXP ncoresSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type LossDiff(LossDiffSEXP);
     Rcpp::traits::input_parameter< int >::type L(LSEXP);
     Rcpp::traits::input_parameter< int >::type B(BSEXP);
-    rcpp_result_gen = Rcpp::wrap(Test_uSPA_cpp(LossDiff, L, B));
+    Rcpp::traits::input_parameter< int >::type ncores(ncoresSEXP);
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    rcpp_result_gen = Rcpp::wrap(Test_uSPA_cpp(LossDiff, L, B, ncores, seed));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -136,10 +144,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_MultiHorizonSPA_QS_cpp", (DL_FUNC) &_MultiHorizonSPA_QS_cpp, 1},
     {"_MultiHorizonSPA_Get_MBB_ID_cpp", (DL_FUNC) &_MultiHorizonSPA_Get_MBB_ID_cpp, 2},
     {"_MultiHorizonSPA_MBB_Variance_cpp", (DL_FUNC) &_MultiHorizonSPA_MBB_Variance_cpp, 2},
-    {"_MultiHorizonSPA_Bootstrap_aSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Bootstrap_aSPA_cpp, 4},
-    {"_MultiHorizonSPA_Bootstrap_uSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Bootstrap_uSPA_cpp, 3},
-    {"_MultiHorizonSPA_Test_aSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Test_aSPA_cpp, 4},
-    {"_MultiHorizonSPA_Test_uSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Test_uSPA_cpp, 3},
+    {"_MultiHorizonSPA_Bootstrap_aSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Bootstrap_aSPA_cpp, 6},
+    {"_MultiHorizonSPA_Bootstrap_uSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Bootstrap_uSPA_cpp, 5},
+    {"_MultiHorizonSPA_Test_aSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Test_aSPA_cpp, 6},
+    {"_MultiHorizonSPA_Test_uSPA_cpp", (DL_FUNC) &_MultiHorizonSPA_Test_uSPA_cpp, 5},
     {"_MultiHorizonSPA_MultiHorizonMCS_cpp", (DL_FUNC) &_MultiHorizonSPA_MultiHorizonMCS_cpp, 9},
     {NULL, NULL, 0}
 };


### PR DESCRIPTION
…a bug in output of the fast SPA tests.

Note: The fast SPA tests now include the RNG seed as a parameter, so the results will be identical if the function is run multiple times without changing the seed.